### PR TITLE
Fix async cleanup in PDF generation

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -3,6 +3,7 @@ import os
 import re
 import asyncio
 import aiofiles
+import aiofiles.os
 
 from pathlib import Path
 from datetime import datetime, timedelta
@@ -154,7 +155,7 @@ async def cleanup_downloads_folder(folder_path: str) -> None:
         filenames = await asyncio.to_thread(os.listdir, folder_path)  # List files in the provided folder path
         for filename in filenames:
             file_path = os.path.join(folder_path, filename)  # Construct full file path
-            if await aiofiles.ospath.isfile(file_path):  # Check if it's a file
+            if await aiofiles.os.path.isfile(file_path):  # Check if it's a file
                 file_mod_time = datetime.fromtimestamp(
                     await asyncio.to_thread(os.path.getmtime, file_path)  # Get the last modification time of the file
 


### PR DESCRIPTION
## Summary
- import `aiofiles.os` for asynchronous file checks
- use `aiofiles.os.path.isfile` in download cleanup

## Testing
- `python - <<'PY'
import os, sys
sys.path.append('/workspace/v-gpt-pdf-generator/app')
os.makedirs('/app/downloads', exist_ok=True)
from fastapi.testclient import TestClient
import dependencies
async def fake_generate_pdf(*args, **kwargs):
    return None
dependencies.generate_pdf = fake_generate_pdf
from main import app
client = TestClient(app)
response = client.post('/', json={'pdf_title':'Test PDF','contains_code':False,'body_content':'<p>Hello world content</p>'})
print('status:', response.status_code)
print('response:', response.json())
PY`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1f9366640832a9bd2835bb856fe84