### PR TITLE
Add unit tests for PDF generation features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - `CreatePDFResponse` model and request field examples.
 - Secured API key handling and enriched route metadata.
 - OpenAPI specification saved as `openapi.json` in the project root.
+- Initial test suite covering API key validation, PDF creation endpoint, and downloads cleanup.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import sys
+import types
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
+weasyprint_stub = types.ModuleType("weasyprint")
+
+
+class HTML:
+    def __init__(self, string):
+        self.string = string
+
+    def write_pdf(self, target):
+        Path(target).write_bytes(b"")
+
+
+weasyprint_stub.HTML = HTML
+
+sys.modules.setdefault("weasyprint", weasyprint_stub)

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,47 @@
+import os
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+from app.dependencies import cleanup_downloads_folder, get_api_key
+
+
+@pytest.mark.asyncio
+async def test_get_api_key_valid(monkeypatch):
+    monkeypatch.setenv("API_KEY", "secret")
+    credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer",
+        credentials="secret",
+    )
+    result = await get_api_key(credentials)
+    assert result == "secret"
+
+
+@pytest.mark.asyncio
+async def test_get_api_key_invalid(monkeypatch):
+    monkeypatch.setenv("API_KEY", "secret")
+    credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer",
+        credentials="wrong",
+    )
+    with pytest.raises(HTTPException) as exc:
+        await get_api_key(credentials)
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_cleanup_downloads_folder(tmp_path):
+    old_file = tmp_path / "old.txt"
+    old_file.write_text("old")
+    old_time = datetime.now() - timedelta(days=8)
+    os.utime(old_file, (old_time.timestamp(), old_time.timestamp()))
+
+    new_file = tmp_path / "new.txt"
+    new_file.write_text("new")
+
+    await cleanup_downloads_folder(str(tmp_path))
+
+    assert not old_file.exists()
+    assert new_file.exists()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+import pytest
+from fastapi.testclient import TestClient
+
+Path("/app/downloads").mkdir(parents=True, exist_ok=True)
+
+from app.main import app  # noqa: E402
+import app.routes.create as create_module  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def fake_generate_pdf(
+    pdf_title,
+    body_content,
+    css_content,
+    output_path,
+    contains_code,
+):
+    Path(output_path).write_bytes(b"PDF")
+
+
+def test_create_pdf_endpoint_success(monkeypatch, tmp_path):
+    monkeypatch.setenv("API_KEY", "secret")
+    monkeypatch.setenv("BASE_URL", "http://test")
+
+    def fake_path(path_str):
+        assert path_str == "/app/downloads"
+        return tmp_path
+
+    monkeypatch.setattr(create_module, "Path", fake_path)
+    monkeypatch.setattr(create_module, "generate_pdf", fake_generate_pdf)
+
+    client = TestClient(app)
+
+    payload = {
+        "pdf_title": "Example PDF",
+        "contains_code": False,
+        "body_content": "<p>Hello World</p>",
+    }
+
+    response = client.post(
+        "/",
+        json=payload,
+        headers={"Authorization": "Bearer secret"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["url"].startswith("http://test")
+    files = list(tmp_path.iterdir())
+    assert len(files) == 1
+    assert files[0].suffix == ".pdf"
+
+
+def test_create_pdf_endpoint_invalid_api_key(monkeypatch):
+    monkeypatch.setenv("API_KEY", "secret")
+    client = TestClient(app)
+    payload = {
+        "pdf_title": "Example PDF",
+        "contains_code": False,
+        "body_content": "<p>Hello World</p>",
+    }
+    response = client.post(
+        "/",
+        json=payload,
+        headers={"Authorization": "Bearer wrong"},
+    )
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- add tests for API key validation and downloads cleanup
- add tests for PDF creation endpoint

## Testing
- `flake8 tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c242723df8832aaffd9e1f55294660