### PR TITLE
feat: enforce input sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,5 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - OpenAPI specification saved as `openapi.json` in the project root.
 - Initial test suite covering API key validation, PDF creation endpoint, and downloads cleanup.
 - Expanded tests for PDF generation helper, request model validation, authentication edge cases, cleanup errors, and route handling.
+### Changed
+- Added strict validation for `CreatePDFRequest` fields including title length, content sanitization, CSS restrictions, and normalized output filenames.

--- a/app/models.py
+++ b/app/models.py
@@ -1,31 +1,43 @@
-from pydantic import BaseModel, Field, HttpUrl
+import re
 from typing import Optional
+
+from pydantic import BaseModel, Field, HttpUrl, validator
 
 
 # Request model for creating a PDF
 class CreatePDFRequest(BaseModel):
     pdf_title: str = Field(
         ...,
-        description="Title of the PDF document; will be used as both the <h1>$title</h1> in the body and the <title>$title</title>.",
+        min_length=1,
+        max_length=200,
+        description=(
+            "Title of the PDF document; will be used as both the "
+            "<h1>$title</h1> in the body and the <title>$title</title>."
+        ),
         example="Example PDF",
     )
     contains_code: bool = Field(
         default=False,
         description=(
-            "Indicates whether the 'body_content' includes code blocks. If set to true, the content may contain pre-formatted "
-            "code blocks using <pre><code> tags. To include code blocks, wrap snippets in <pre><code>...</code></pre> tags and "
-            "specify the language using a class attribute, e.g., <code class=\"language-python\"></code>."
+            "Indicates whether the 'body_content' includes code blocks. "
+            "If set to true, the content may contain pre-formatted code blocks "
+            "using <pre><code> tags. To include code blocks, wrap snippets in "
+            "<pre><code>...</code></pre> tags and specify the language using a "
+            "class attribute, e.g., <code class=\"language-python\"></code>."
         ),
         example=True,
     )
     body_content: str = Field(
         ...,
         description=(
-            "HTML content for the PDF body. This will be inserted inside the <body> element of the PDF document. "
-            "Use the 'pdf_title' parameter to set the <h1> heading; do not include an <h1> tag in the 'body_content'. "
-            "You can use standard HTML tags such as <h2>, <h3>, <h4>, <p>, <div>, <span>, <ul>, <ol>, <li>, <img>, <a>, <table>, <tr>, <th>, <td>, etc., to structure your content. "
-            "Include classes and IDs within the HTML elements and use the 'css_content' parameter to apply custom styles. "
-            "Images should use absolute URLs. "
+            "HTML content for the PDF body. This will be inserted inside the "
+            "<body> element of the PDF document. Use the 'pdf_title' parameter "
+            "to set the <h1> heading; do not include an <h1> tag in the "
+            "'body_content'. You can use standard HTML tags such as <h2>, <h3>, "
+            "<h4>, <p>, <div>, <span>, <ul>, <ol>, <li>, <img>, <a>, <table>, "
+            "<tr>, <th>, <td>, etc., to structure your content. Include classes "
+            "and IDs within the HTML elements and use the 'css_content' "
+            "parameter to apply custom styles. Images should use absolute URLs. "
             "Scripts and embedded forms are not supported."
         ),
         example="<p>Hello World</p>",
@@ -33,16 +45,63 @@ class CreatePDFRequest(BaseModel):
     css_content: Optional[str] = Field(
         default=None,
         description=(
-            "Optional CSS styles to format the 'body_content' using selectors like tags, classes, and IDs. "
-            "Provide custom styles or override default styles to achieve the desired layout and design."
+            "Optional CSS styles to format the 'body_content'. Supports "
+            "standard selectors and properties but disallows '@import', "
+            "'url()' functions, and '<script>' tags."
         ),
         example="p { color: blue; }",
     )
     output_filename: Optional[str] = Field(
         default=None,
-        description="Optional filename for the generated PDF. Use hyphens for spaces and do not include the file extension.",
+        description=(
+            "Optional filename for the generated PDF. Use lowercase letters, "
+            "numbers, hyphens, or underscores. Path separators are not allowed "
+            "and the '.pdf' extension is appended automatically."
+        ),
         example="example-pdf",
     )
+
+    @validator("pdf_title", pre=True)
+    def strip_title(cls, value: str) -> str:
+        if isinstance(value, str):
+            value = value.strip()
+        return value
+
+    @validator("body_content")
+    def validate_body(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("body_content cannot be empty")
+        prohibited = [r"<\s*h1\b", r"<\s*script\b", r"<\s*form\b"]
+        for pattern in prohibited:
+            if re.search(pattern, value, re.IGNORECASE):
+                raise ValueError("body_content contains prohibited tags")
+        return value
+
+    @validator("css_content")
+    def validate_css(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        lowered = value.lower()
+        if any(term in lowered for term in ["@import", "url(", "<script"]):
+            raise ValueError("css_content contains disallowed constructs")
+        return value
+
+    @validator("output_filename", pre=True)
+    def sanitize_filename(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        value = value.strip().lower()
+        if "/" in value or "\\" in value:
+            raise ValueError("output_filename cannot contain path separators")
+        if value.endswith(".pdf"):
+            value = value[:-4]
+        if not value:
+            raise ValueError("output_filename cannot be empty")
+        if len(value) > 100:
+            raise ValueError("output_filename is too long")
+        if not re.fullmatch(r"[a-z0-9_-]+", value):
+            raise ValueError("output_filename contains invalid characters")
+        return f"{value}.pdf"
 
 
 # Response model for PDF creation

--- a/app/routes/create.py
+++ b/app/routes/create.py
@@ -62,7 +62,7 @@ async def create_pdf(request: CreatePDFRequest):
     filename = (
         f"{random_chars}{filename_suffix}.pdf"
         if request.output_filename is None
-        else f"{request.output_filename}{filename_suffix}.pdf"
+        else f"{request.output_filename[:-4]}{filename_suffix}.pdf"
     )
     output_path = Path("/app/downloads") / filename
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,9 +16,55 @@ def test_create_pdf_request_optional_fields():
         pdf_title="Title",
         body_content="<p>x</p>",
         css_content="p{color:red;}",
-        output_filename="file",
+        output_filename="File",
         contains_code=True,
     )
     assert req.css_content == "p{color:red;}"
-    assert req.output_filename == "file"
+    assert req.output_filename == "file.pdf"
     assert req.contains_code is True
+
+
+@pytest.mark.parametrize("title", ["", "   ", "x" * 201])
+def test_pdf_title_validation(title):
+    with pytest.raises(ValidationError):
+        CreatePDFRequest(pdf_title=title, body_content="<p>x</p>")
+
+
+@pytest.mark.parametrize(
+    "body",
+    ["", "   ", "<h1>bad</h1>", "<script>alert(1)</script>", "<form></form>"],
+)
+def test_body_content_validation(body):
+    with pytest.raises(ValidationError):
+        CreatePDFRequest(pdf_title="Title", body_content=body)
+
+
+@pytest.mark.parametrize(
+    "css",
+    ["@import url('x')", "body{background:url('x')}", "<script></script>"],
+)
+def test_css_content_validation(css):
+    with pytest.raises(ValidationError):
+        CreatePDFRequest(pdf_title="Title", body_content="<p>x</p>", css_content=css)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["bad/name", "bad\\name", "bad name", "a" * 101],
+)
+def test_output_filename_invalid(filename):
+    with pytest.raises(ValidationError):
+        CreatePDFRequest(
+            pdf_title="Title",
+            body_content="<p>x</p>",
+            output_filename=filename,
+        )
+
+
+def test_output_filename_sanitized():
+    req = CreatePDFRequest(
+        pdf_title="Title",
+        body_content="<p>x</p>",
+        output_filename=" My_File ",
+    )
+    assert req.output_filename == "my_file.pdf"


### PR DESCRIPTION
## Summary
- strengthen CreatePDFRequest validation for titles, HTML/CSS content, and filenames
- sanitize filenames in create route to match new model behavior
- expand model tests to cover invalid inputs

## Testing
- `flake8 --max-line-length=120 app/models.py app/routes/create.py tests/test_models.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c28d50f904832a9dab98b265717cb8