### PR TITLE
Refactor async file operations and handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Simplified OpenAPI server configuration using `BASE_URL` and `ROOT_PATH` environment variables.
 - Replaced deprecated `@validator` decorators with Pydantic v2 `@field_validator` in `CreatePDFRequest`.
 - Manage startup and shutdown with FastAPI lifespan context.
+- Refactored blocking operations using `asyncio.to_thread` and converted several async helpers to synchronous functions.

--- a/app/main.py
+++ b/app/main.py
@@ -72,7 +72,7 @@ app.include_router(pdf_router)
         }
     },
 )
-async def download_pdf(
+def download_pdf(
     filename: str = Path(..., description="Name of the PDF file to download", example="example.pdf")
 ):
     file_path = f"/app/downloads/{filename}"
@@ -117,7 +117,7 @@ app.openapi = custom_openapi
 
 
 @app.exception_handler(HTTPException)
-async def http_exception_handler(request: Request, exc: HTTPException):
+def http_exception_handler(request: Request, exc: HTTPException):
     if isinstance(exc.detail, dict):
         return JSONResponse(status_code=exc.status_code, content=exc.detail)
     return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -8,37 +8,34 @@ from fastapi.security import HTTPAuthorizationCredentials
 from app.dependencies import cleanup_downloads_folder, get_api_key
 
 
-@pytest.mark.asyncio
-async def test_get_api_key_valid(monkeypatch):
+def test_get_api_key_valid(monkeypatch):
     monkeypatch.setenv("API_KEY", "secret")
     credentials = HTTPAuthorizationCredentials(
         scheme="Bearer",
         credentials="secret",
     )
-    result = await get_api_key(credentials)
+    result = get_api_key(credentials)
     assert result == "secret"
 
 
-@pytest.mark.asyncio
-async def test_get_api_key_invalid(monkeypatch):
+def test_get_api_key_invalid(monkeypatch):
     monkeypatch.setenv("API_KEY", "secret")
     credentials = HTTPAuthorizationCredentials(
         scheme="Bearer",
         credentials="wrong",
     )
     with pytest.raises(HTTPException) as exc:
-        await get_api_key(credentials)
+        get_api_key(credentials)
     assert exc.value.status_code == 403
 
 
-@pytest.mark.asyncio
-async def test_get_api_key_no_env(monkeypatch):
+def test_get_api_key_no_env(monkeypatch):
     monkeypatch.delenv("API_KEY", raising=False)
     credentials = HTTPAuthorizationCredentials(
         scheme="Bearer",
         credentials="provided",
     )
-    result = await get_api_key(credentials)
+    result = get_api_key(credentials)
     assert result == "provided"
 
 


### PR DESCRIPTION
## Summary
- make download endpoint and HTTP exception handler synchronous
- shift blocking file work to `asyncio.to_thread`
- simplify API key dependency and update tests

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2bd1db41c832abacd62c19376e396