### PR TITLE
Allow relative download URLs when BASE_URL is unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,5 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Adopted Pydantic v2 `ConfigDict` configuration for `CreatePDFResponse`.
 - Restricted model responses to forbid extra fields and return `CreatePDFResponse` from the create route.
 - Pass CSS content directly to the PDF generator without forcing an empty string.
+### Fixed
+- Create endpoint now returns a relative download URL when `BASE_URL` is unset instead of failing.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The project is a robust PDF Generation API built on FastAPI, designed to streaml
    ```
 
    The response includes a `url` to download the generated PDF from `/downloads`.
+   If `BASE_URL` is not set, this will be a relative path.
 ---
 
 ## 🛠 Project Changelog

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 # main.py
 from contextlib import asynccontextmanager
 from pathlib import Path as FilePath
-from typing import AsyncGenerator, Any
+from typing import AsyncGenerator
 
 from fastapi import FastAPI, HTTPException, Path, Request
 from fastapi.responses import FileResponse, JSONResponse

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 import re
 from typing import Optional
 
-from pydantic import BaseModel, Field, HttpUrl, field_validator, ConfigDict
+from pydantic import BaseModel, Field, field_validator, ConfigDict
 
 
 # Request model for creating a PDF
@@ -118,9 +118,18 @@ class CreatePDFResponse(BaseModel):
     results: str = Field(
         ..., description="Outcome message for the PDF generation request"
     )
-    url: HttpUrl = Field(
-        ..., description="URL where the generated PDF can be downloaded"
+    url: str = Field(
+        ..., description="URL where the generated PDF can be downloaded",
+        json_schema_extra={"format": "uri"},
     )
+
+    @field_validator("url")
+    def validate_url(cls, value: str) -> str:
+        if value.startswith("http://") or value.startswith("https://"):
+            return value
+        if value.startswith("/"):
+            return value
+        raise ValueError("url must be absolute or start with '/' for a relative path")
 
     model_config = ConfigDict(
         extra="forbid",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -84,3 +84,14 @@ def test_extra_fields_forbidden_response_models():
         ErrorResponse(status=400, code="err", message="m", extra="x")
     with pytest.raises(ValidationError):
         CreatePDFResponse(results="ok", url="http://example.com", extra="x")
+
+
+def test_create_pdf_response_allows_relative_url():
+    resp = CreatePDFResponse(results="ok", url="/downloads/file.pdf")
+    assert resp.url == "/downloads/file.pdf"
+
+
+@pytest.mark.parametrize("url", ["downloads/file.pdf", "ftp://example.com/file.pdf"])
+def test_create_pdf_response_url_validation(url):
+    with pytest.raises(ValidationError):
+        CreatePDFResponse(results="ok", url=url)


### PR DESCRIPTION
## Summary
- permit relative URLs in `CreatePDFResponse` so the create endpoint works without `BASE_URL`
- add regression tests for relative URLs and update docs
- remove unused import caught by lint

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2cccfb504832ab57c8f0a2d85cf65