### PR TITLE
test: mock Path.iterdir in cleanup error test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,4 +36,5 @@ See [standard-version](https://github.com/conventional-changelog/standard-versio
 - Narrowed exception handling with explicit logging.
 - Documented create route with type hints and docstring.
 ### Fixed
+- Improved cleanup error test to simulate `Path.iterdir` failure.
 - Create endpoint now returns a relative download URL when `BASE_URL` is unset instead of failing.

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -45,10 +45,10 @@ async def test_cleanup_downloads_folder(tmp_path):
 
 @pytest.mark.asyncio
 async def test_cleanup_downloads_folder_error(monkeypatch, tmp_path):
-    def fail_listdir(path):
+    def fail_iterdir(self):
         raise OSError("boom")
 
-    monkeypatch.setattr(os, "listdir", fail_listdir)
+    monkeypatch.setattr("app.dependencies.Path.iterdir", fail_iterdir)
     with pytest.raises(HTTPException) as exc:
         await cleanup_downloads_folder(str(tmp_path))
     assert exc.value.status_code == 500


### PR DESCRIPTION
## Summary
- use Path.iterdir to simulate failures in cleanup test
- document test improvement in changelog

## Testing
- `flake8 tests/test_dependencies.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2d161fca8832a80b8ee80d3e34844